### PR TITLE
Fixed regular expressions to be able to handle prefixed pathes.

### DIFF
--- a/cosmo-core/src/main/java/org/unitedinternet/cosmo/server/CollectionPath.java
+++ b/cosmo-core/src/main/java/org/unitedinternet/cosmo/server/CollectionPath.java
@@ -1,12 +1,12 @@
 /*
  * Copyright 2006 Open Source Applications Foundation
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -40,7 +40,7 @@ public class CollectionPath {
     private static final Log LOG = LogFactory.getLog(CollectionPath.class);
 
     private static final Pattern PATTERN_COLLECTION_UID =
-        Pattern.compile("^/collection/([^/]+)(/.*)?$");
+        Pattern.compile("^.*/collection/([^/]+)(/.*)?$");
 
     private String urlPath;
     private String uid;

--- a/cosmo-core/src/main/java/org/unitedinternet/cosmo/server/ItemPath.java
+++ b/cosmo-core/src/main/java/org/unitedinternet/cosmo/server/ItemPath.java
@@ -1,12 +1,12 @@
 /*
  * Copyright 2006 Open Source Applications Foundation
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -40,7 +40,7 @@ public class ItemPath {
     private static final Log LOG = LogFactory.getLog(ItemPath.class);
 
     private static final Pattern PATTERN_ITEM_UID =
-        Pattern.compile("^/(item|expanded|detached)/([^/]+)(/.*)?$");
+        Pattern.compile("^.*/(item|expanded|detached)/([^/]+)(/.*)?$");
 
     private String urlPath;
     private String uid;

--- a/cosmo-core/src/main/java/org/unitedinternet/cosmo/server/UserPath.java
+++ b/cosmo-core/src/main/java/org/unitedinternet/cosmo/server/UserPath.java
@@ -1,12 +1,12 @@
 /*
  * Copyright 2006 Open Source Applications Foundation
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -40,7 +40,7 @@ public class UserPath {
     private static final Log LOG = LogFactory.getLog(UserPath.class);
 
     private static final Pattern PATTERN_USER_USERNAME =
-        Pattern.compile("^/user/([^/]+)(/.*)?$");
+        Pattern.compile("^.*/user/([^/]+)(/.*)?$");
 
     private String urlPath;
     private String username;


### PR DESCRIPTION
Hi,
I'm using cosmo embedded in an OSGi enviroment where all servlets and filters are prefixed with pathes like /calendar. When using tickets the given path is used to find resources. This results in errors like this:
TicketedItemNotFoundException: Resource at /calendar/dav/item/99a0533b-0035-47f0-a6d1-acb96218811e not found

I tried different Spring solutions like adding Springs ForwardedHeaderFilter. But none worked because the finally the TicketProcessingFilter uses httpRequest.getPathInfo() which always gets the full path.

With this PR i suggest to make the path parsing using the resource pathes more tollerant by allowing prefixed pathes. This make tickets work again for me.

The regular expressions now can handle pathes like:
/something/item/...
/item/...
/another/user/...
/user
/any/prefix/path/collection/..