### PR TITLE
Add missing format argument for LOG.warn

### DIFF
--- a/cosmo-core/src/main/java/org/unitedinternet/cosmo/security/impl/CosmoSecurityManagerImpl.java
+++ b/cosmo-core/src/main/java/org/unitedinternet/cosmo/security/impl/CosmoSecurityManagerImpl.java
@@ -140,7 +140,7 @@ public class CosmoSecurityManagerImpl implements CosmoSecurityManager {
             if (user.equals(item.getOwner())) {
                 return;
             }
-            LOG.warn("User {} attempted access to item {} owned by {}", user.getUsername(), item.getUid());
+            LOG.warn("User {} attempted access to item {} owned by {}", user.getUsername(), item.getUid(), item.getOwner().getUsername());
             throw new PermissionDeniedException("User does not have appropriate permissions on item " + item.getUid());
         }
 


### PR DESCRIPTION
The call to `LOG.warn` has three placeholders but only two values are passed in. This PR adds item.getOwner().getUsername() as the third parameter.